### PR TITLE
Alterações de estilo no HVC

### DIFF
--- a/src/HVC.ts
+++ b/src/HVC.ts
@@ -102,7 +102,6 @@ export default class HVC {
      * Pausa a execução da HVM.
      */
     public async stop() {
-        console.log("parou!");
         
         this.HVM.debugger.setState("PAUSADO")
     }
@@ -111,7 +110,6 @@ export default class HVC {
      * Continua a execução da HVM.
      */
     public async continue() {
-        console.log("Voltou");
         
         this.HVM.debugger.setState("RODANDO");
         await this.HVM.execute_debug()

--- a/src/hvm/EPI.ts
+++ b/src/hvm/EPI.ts
@@ -4,8 +4,8 @@ export default class EPI {
 
     public registrar(registro: number) {
 
-        if (registro < 0) 
-            throw new Error("Erro de sobrecarga da pilha, limite de 100 registros");
+        if (registro < 0 || registro > 99) 
+            throw new Error("Valor inválido no EPI: " + registro.toString() + ".");
 
         this.valor = registro;
         

--- a/src/hvm/FolhaDeSaida.ts
+++ b/src/hvm/FolhaDeSaida.ts
@@ -13,7 +13,7 @@ export default class FolhaDeSaida {
             return
 
         }
-        throw new Error("Nenhuma implementação de saída encontrada")
+        throw new Error("Nenhuma implementação de saída encontrada.")
 
     }
 

--- a/src/hvm/Gaveteiro.ts
+++ b/src/hvm/Gaveteiro.ts
@@ -43,7 +43,7 @@ export default class Gaveteiro {
         final = cartao == "000"
 
       } else
-        throw new Error("Falha na carga do porta cartões para gaveteiro");
+        throw new Error("Falha na carga do porta cartões para gaveteiro.");
 
       index++
 
@@ -56,19 +56,19 @@ export default class Gaveteiro {
   public registrar(endereco: number, valor: string) {
 
     if(endereco + 1 > this.gavetas.length)
-      throw new Error(`Sobrecarga de gavetas. Limite de ${this.gavetas.length} registros`);
+      throw new Error(`Sobrecarga de gavetas. Limite de ${this.gavetas.length} registros.`);
     else if(endereco < 0)
-      throw new Error(`Estouro negativo de gavetas. As gavetas vão de 0 a ${this.gavetas.length} registros`);
+      throw new Error(`Estouro negativo de gavetas. As gavetas vão de 0 a ${this.gavetas.length} registros.`);
 
     if((endereco < this.ultimoRestrito) && this.ultimoRestrito > 0){
       const conteudo = this.ler(endereco);
-      throw new Error(`Tentativa de sobrescrita em gaveta que armazena código fonte. Conteúdo da gaveta [${endereco}]: ${conteudo}`);
+      throw new Error(`Tentativa de sobrescrita em gaveta que armazena código fonte. Conteúdo da gaveta [${endereco}]: ${conteudo}.`);
     }
 
     const numeric_value = parseInt(valor)
 
     if (numeric_value < -99 || numeric_value > 999)
-      throw new Error(`Valor inválido de escrita em gaveta [${endereco}]:${numeric_value}`)
+      throw new Error(`Valor inválido de escrita em gaveta [${endereco}]:${numeric_value}.`)
 
     this.gavetas[endereco] = valor
 
@@ -83,7 +83,7 @@ export default class Gaveteiro {
   public ler(endereco: number){
 
     if (endereco < 0 || endereco > this.gavetas.length || !this.gavetas[endereco])   
-      throw new Error(`Tentativa de leitura em endereço inexistente. Gaveta [${endereco}]`);
+      throw new Error(`Tentativa de leitura em endereço inexistente. Gaveta [${endereco}].`);
 
 
     return this.gavetas[endereco];

--- a/src/hvm/PortaCartoes.ts
+++ b/src/hvm/PortaCartoes.ts
@@ -12,9 +12,9 @@ export default class PortaCartoes {
                 const number_value = Number(cartao)
 
                 if (number_value < -99 || number_value > 999) 
-                    throw new Error(`Inserção de formato númerico inválido. Conteudo do cartão: ${cartao}`);
+                    throw new Error(`Inserção de formato numérico inválido. Conteúdo do cartão: ${cartao}.`);
 
-                throw new Error(`Inserção de um formato desconhecido em cartão. Conteudo do cartão: ${cartao}`);
+                throw new Error(`Inserção de um formato desconhecido em cartão. Conteúdo do cartão: ${cartao}.`);
 
             }
 
@@ -61,7 +61,7 @@ export default class PortaCartoes {
             return
 
         }
-        throw new Error("Nenhuma implementação de entrada encontrada")
+        throw new Error("Nenhuma implementação de entrada encontrada.")
 
     }
 

--- a/test/LDC.test.ts
+++ b/test/LDC.test.ts
@@ -125,7 +125,7 @@ describe('Ocorrência de falhas', () => {
 
     hvc.setCode("0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-13 0-45 0-34 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-10 0-12 0-13 0-13 0-45 0-34 000")
 
-    await expect(hvc.run()).rejects.toThrow("Sobrecarga de gavetas. Limite de 100 registros");
+    await expect(hvc.run()).rejects.toThrow("Sobrecarga de gavetas. Limite de 100 registros.");
 
   });
   it('Ultrapassando limite de valor de entrada', async() => {
@@ -136,7 +136,7 @@ describe('Ocorrência de falhas', () => {
 
     hvc.setCode("750 000")
 
-    await expect(hvc.run()).rejects.toThrow("Inserção de formato númerico inválido. Conteudo do cartão: 10000");
+    await expect(hvc.run()).rejects.toThrow("Inserção de formato numérico inválido. Conteúdo do cartão: 10000.");
 
   });
   it('Tentando acessar gaveta restrita para código fonte', async() => {
@@ -145,7 +145,7 @@ describe('Ocorrência de falhas', () => {
 
     hvc.setCode("0-100 100 000")
 
-    await expect(hvc.run()).rejects.toThrow("Tentativa de sobrescrita em gaveta que armazena código fonte. Conteúdo da gaveta [0]: 0-100");
+    await expect(hvc.run()).rejects.toThrow("Tentativa de sobrescrita em gaveta que armazena código fonte. Conteúdo da gaveta [0]: 0-100.");
   })
   it('Operação com gaveta sem valor', async() => {
     entradas = []
@@ -153,7 +153,7 @@ describe('Ocorrência de falhas', () => {
 
     hvc.setCode("0-50 130 031 000")
 
-    await expect(hvc.run()).rejects.toThrow("Tentativa de leitura em endereço inexistente. Gaveta [31]");
+    await expect(hvc.run()).rejects.toThrow("Tentativa de leitura em endereço inexistente. Gaveta [31].");
   })
   it('Operação com epi para gaveta sem instrução', async() => {
     entradas = []
@@ -161,7 +161,7 @@ describe('Ocorrência de falhas', () => {
 
     hvc.setCode("0-100 930 000")
 
-    expect(hvc.run()).rejects.toThrow("Tentativa de leitura em endereço inexistente. Gaveta [30]");
+    expect(hvc.run()).rejects.toThrow("Tentativa de leitura em endereço inexistente. Gaveta [30].");
   })
 });
 


### PR DESCRIPTION
Novamente foram corrigidas as mensagens de erro da HVM, para entrar em acordo com a norma padrão da língua portuguesa.
Também foram removidos logs sobressalentes do desenvolvimento, afim de evitar mensagens desnecessárias para o usuário final.