### PR TITLE
Histórico da folha de saída

### DIFF
--- a/src/hvm/DAO.ts
+++ b/src/hvm/DAO.ts
@@ -3,7 +3,7 @@ import HVM from "./HVM";
 export default class DAO{
     valorEpi:number;
     gaveteiro:string[] = [];
-    folhaDeSaida:string;
+    folhaDeSaida:string[] = [];
     portaCartoes:string[] = [];
     acumulador:number;
     enderecoAtual:number;
@@ -11,7 +11,7 @@ export default class DAO{
     constructor(hvm:HVM, enderecoAtual:number){
         
         this.valorEpi = hvm.epi.lerRegistro();
-        this.folhaDeSaida = hvm.folhaDeSaida.getText();
+        this.folhaDeSaida = structuredClone(hvm.folhaDeSaida.getText() as string[]);
         this.acumulador = hvm.calculadora.getAcumulador();
         
         this.gaveteiro = new Array<string>(hvm.gaveteiro.getGavetas().length)

--- a/src/hvm/Debugger.ts
+++ b/src/hvm/Debugger.ts
@@ -22,7 +22,13 @@ export default class Debugger{
         const estado = this.estados.pop()
         
         hvm.calculadora.acumular(estado!.acumulador)
-        hvm.folhaDeSaida.imprimir(estado!.folhaDeSaida)
+
+        let saida = estado!.folhaDeSaida.pop()
+
+        hvm.folhaDeSaida.setText(estado!.folhaDeSaida)
+        
+        if(saida)
+            hvm.folhaDeSaida.imprimir(saida)
         
         hvm.gaveteiro.setGavetas(estado!.gaveteiro)
         

--- a/src/hvm/FolhaDeSaida.ts
+++ b/src/hvm/FolhaDeSaida.ts
@@ -2,12 +2,12 @@ import { Internalization } from "../utils/Internalization";
 
 export default class FolhaDeSaida {
 
-    private text:string = "";
+    private text:string[] = [];
 
     public saida?:(out:string) => void
     
     public imprimir(texto: string) {
-        this.text = texto;
+        this.text.push(texto);
         if (this.saida)  {
 
             this.saida(texto)
@@ -18,8 +18,15 @@ export default class FolhaDeSaida {
         throw new Error(Internalization.getInstance().translate("not_implemented_out"))
 
     }
+    public setText(saidas:string[]){
+        this.text = saidas;
+    }
 
-    getText(){
+    public getText(id?:number):string[] | string{
+        
+        if(id != undefined)
+            return this.text[id];
+
         return this.text;
     }
 }

--- a/test/LDC.test.ts
+++ b/test/LDC.test.ts
@@ -337,4 +337,27 @@ describe('Depurador', ()=>{
     await hvc.back()
     await hvc.next()
   })
+  it("Salvar saídas anteriores", async()=>{
+    entradas = []
+    saida = ""
+    hvc.setCode("0-1 120 0-2 121 820 821 000")
+
+    await hvc.debug(0, true, "PAUSADO")
+
+    await hvc.next()
+    await hvc.next()
+    await hvc.next()
+    await hvc.next()
+    await hvc.next()
+
+    expect(hvc.getHVM().folhaDeSaida.getText().length).toBe(1)
+    expect(saida).toBe("1\n")
+    await hvc.next()
+    expect(hvc.getHVM().folhaDeSaida.getText().length).toBe(2)
+    expect(saida).toBe("1\n2\n")
+    await hvc.back()
+    expect(saida).toBe("1\n2\n1\n")
+    expect(hvc.getHVM().folhaDeSaida.getText().length).toBe(1)
+
+  })
 })


### PR DESCRIPTION
Agora é possível acessar os registros anteriores da folha de saída. No modo de depuração, o histórico de saídas é atualizado sempre para o contexto atual do código. Isso significa que, se acabou de haver uma saída e back() for chamada, essa saída será excluída do histórico.